### PR TITLE
[DO NOT MERGE]CHAT-2219: Modify libjingle to support BOSH in Webrtc XMPP stack

### DIFF
--- a/talk/libjingle.gyp
+++ b/talk/libjingle.gyp
@@ -553,6 +553,8 @@
         'xmpp/xmpptask.h',
         'xmpp/xmppthread.cc',
         'xmpp/xmppthread.h',
+        'xmpp/contentwrapper.cc',
+        'xmpp/contentwrapper.h',
       ],
       'conditions': [
         ['OS=="android"', {

--- a/talk/xmpp/contentwrapper.cc
+++ b/talk/xmpp/contentwrapper.cc
@@ -1,0 +1,214 @@
+#include "contentwrapper.h"
+
+#include <stdlib.h>
+
+namespace buzz{
+
+  ContentWrapper::ContentWrapper(const std::string& host, const std::string& lang): host(host), lang(lang){};
+
+  ContentWrapper::~ContentWrapper(){};
+
+  std::string ContentWrapper::GenerateLoginStart()
+  {
+    std::string start_string = "<stream:stream to=\'" + host + "\' ";
+    start_string += "xml:lang=\'" + lang + "\' ";
+    start_string += "version=\'1.0\' ";
+    start_string += "xmlns:stream=\'http://etherx.jabber.org/streams\' ";
+    start_string += "xmlns=\'jabber:client\'>\r\n";
+    return start_string;
+  }
+
+  std::string ContentWrapper::GenerateLoginRestart()
+  {
+    return GenerateLoginStart();
+  }
+
+  std::string ContentWrapper::GenerateLogout()
+  {
+    return "</stream:stream>";
+  }
+
+  std::string ContentWrapper::GenerateRequest(const std::string& xml)
+  {
+    return xml;
+  }
+
+  bool ContentWrapper::HandleRecvData(std::string& xml, std::size_t len)
+  {
+    xml = xml.substr(0, len);
+    return true;
+  }
+
+  BoshContentWrapper::BoshContentWrapper(const std::string& host, const std::string& lang, const std::string& server, int port) :
+    ContentWrapper(host, lang),
+    server(server),
+    port(port),
+    rid(0),
+    sid(""),
+    path("/http-bind/"),
+    start_sent(false)
+  {
+    bosh_host = host + ":" + std::to_string((long)port);
+  }
+
+  BoshContentWrapper::~BoshContentWrapper()
+  {
+  }
+
+  std::string BoshContentWrapper::GenerateLoginStart()
+  {
+    start_sent = true;
+    std::string start_string = GetStartString();
+    return WrapHtmlRequest(start_string);
+  }
+
+  std::string BoshContentWrapper::GenerateLoginRestart()
+  {
+    start_sent = true;
+    std::string restart_string = GetRestartString();
+    return WrapHtmlRequest(restart_string); 
+  }
+
+  std::string BoshContentWrapper::GenerateLogout()
+  {
+    std::string logout_string = GetLogoutString();
+    return WrapHtmlRequest(logout_string);
+  }
+
+  std::string BoshContentWrapper::GenerateRequest(const std::string& xml)
+  {
+    std::string request = WrapBodyTag(xml);
+    return WrapHtmlRequest(request);
+  }
+
+  std::string BoshContentWrapper::GetLogoutString()
+  {
+    ++rid;
+    std::string requestbody = "<body";
+    requestbody += "rid=\'" + std::to_string((long)rid) + "\' ";
+    requestbody += "sid=\'" + sid + "\' ";
+    requestbody += "type=\'terminate\'";
+    requestbody += "xmlns=\'" + kXmlnsHttpbind + "\'/>";
+    rid = 0;
+    sid = "";
+    start_sent = false;
+    return requestbody;
+  }
+
+  std::string BoshContentWrapper::GetStartString()
+  {
+    rid = rand() % 100000 + 1728679472;
+    std::string requestbody = "<body ";
+    requestbody += "xmlns=\'" + kXmlnsHttpbind + "\' ";
+    requestbody += "xmlns:xmpp=\'" + kXmlnsXmppBosh + "\' ";
+    requestbody += "content=\'text/xml; charset=utf-8\' ";
+    requestbody += "to=\'" + host + "\' ";
+    requestbody += "rid=\'" + std::to_string((long)rid) + "\' ";
+    requestbody += "route=\'xmpp:" + server + ":5222\' ";
+    requestbody += "xmpp:version=\'1.0\' ";
+    requestbody += "/>";
+    return requestbody;
+
+  }
+
+  std::string BoshContentWrapper::GetRestartString()
+  {
+    ++rid;
+    std::string requestbody = "<body ";
+    requestbody += "xmlns=\'" + kXmlnsHttpbind + "\' ";
+    requestbody += "xmlns:xmpp=\'" + kXmlnsXmppBosh + "\' ";
+    requestbody += "rid=\'" + std::to_string((long)rid) + "\' ";
+    requestbody += "sid=\'" + sid + "\' ";
+    requestbody += "xmpp:restart=\'true\' ";
+    requestbody += "to=\'" + host + "\' ";
+    requestbody += "/>";
+
+    return requestbody;
+  }
+
+  std::string BoshContentWrapper::WrapBodyTag(const std::string& xml)
+  {
+    ++rid;
+    std::string requestbody = "<body ";
+
+    requestbody += "xmlns=\'" + kXmlnsHttpbind + "\' ";
+    requestbody += "rid=\'" + std::to_string((long)rid) + "\' ";
+    requestbody += "sid=\'" + sid + "\'>";
+    requestbody += xml;
+    requestbody += "</body>";
+
+    return requestbody;
+  }
+
+  std::string BoshContentWrapper::WrapHtmlRequest(const std::string& str)
+  {
+    std::string request = "POST " + path + " HTTP/1.1\r\n";
+    request += "Host: " + bosh_host + "\r\n";
+    request += "Content-Type: text/xml; charset=utf-8\r\n";
+    request += "Content-Length: " + std::to_string((long)str.length()) + "\r\n\r\n";
+    request += str;
+
+    return request;
+  }
+
+  bool BoshContentWrapper::CollectSid(const std::string& body)
+  {
+    std::size_t pos = body.find("sid");
+    if (pos == std::string::npos)
+      return false;
+    std::string temp = body.substr(pos + 5, body.length() - pos - 5);
+    pos = temp.find_first_of("\'");
+    if (pos == std::string::npos)
+      return false;
+    sid = temp.substr(0, pos);
+    return true;
+  }
+
+  bool BoshContentWrapper::HandleRecvData(std::string& str, std::size_t len)
+  {
+    std::string content = str.substr(0, len);
+    // Find the position of <body...
+    std::size_t start_body = content.find_first_of("<");
+    if (start_body == std::string::npos)
+    {
+      return false;
+    }
+    content = content.substr(start_body, len - start_body);
+    
+    // Collect the sid of message
+    if (sid == "")
+    {
+      if (!CollectSid(content))
+      {
+        return false;
+      }
+    }
+
+    // Process the return string of start/restart messages
+    if (start_sent)
+    {
+      // Find the position of </body>
+      std::size_t end_body = content.find_last_of("<");
+      if (end_body == std::string::npos)
+      {
+        return false;
+      }
+      content = content.substr(0, end_body);
+      start_sent = false;
+    }
+    // Process the return string of other messages
+    else
+    {
+      //Remove the <body...> and </body> tags
+      std::size_t start = content.find_first_of(">");
+      std::size_t stop = content.find_last_of("<");
+      if (start == std::string::npos || stop == std::string::npos)
+      {
+        return false;
+      }
+      content = content.substr(start + 1, stop - start - 1);
+    }
+    str = content;
+    return true;
+  }
+}

--- a/talk/xmpp/contentwrapper.h
+++ b/talk/xmpp/contentwrapper.h
@@ -1,0 +1,53 @@
+#ifndef TALK_XMPP_CONTENTWRAPPER_H_
+#define TALK_XMPP_CONTENTWRAPPER_H_
+
+#include <string>
+
+namespace buzz{
+  class ContentWrapper
+  {
+  public:
+    ContentWrapper(const std::string& host, const std::string& lang);
+    ~ContentWrapper();
+    virtual std::string GenerateLoginStart();
+    virtual std::string GenerateLoginRestart();
+    virtual std::string GenerateLogout();
+    virtual std::string GenerateRequest(const std::string& str);
+    virtual bool HandleRecvData(std::string& str, std::size_t len);
+  protected:
+    std::string host;
+    std::string lang;
+  };
+
+  class BoshContentWrapper : public ContentWrapper
+  {
+  public:
+    BoshContentWrapper(const std::string& host, const std::string& lang, const std::string& server, int port);
+    ~BoshContentWrapper();
+    std::string GenerateLoginStart();
+    std::string GenerateLoginRestart();
+    std::string GenerateLogout();
+    std::string GenerateRequest(const std::string& str);
+    bool HandleRecvData(std::string& str, std::size_t len);
+
+  private:
+    bool CollectSid(const std::string& body);
+    std::string GetStartString();
+    std::string GetRestartString();
+    std::string GetLogoutString();
+    std::string WrapBodyTag(const std::string& str);
+    std::string WrapHtmlRequest(const std::string& str);
+
+    const std::string kXmlnsHttpbind = "http://jabber.org/protocol/httpbind";
+    const std::string kXmlnsXmppBosh = "urn:xmpp:xbosh";
+    unsigned long rid;
+    std::string sid;
+    std::string path;
+    std::string server;
+    int port;
+    std::string bosh_host;
+    bool start_sent;
+  };
+}
+
+#endif  // TALK_XMPP_CONTENTWRAPPER_H_

--- a/talk/xmpp/xmppclient.cc
+++ b/talk/xmpp/xmppclient.cc
@@ -154,8 +154,10 @@ XmppReturnStatus XmppClient::Connect(
 
   // Set language
   d_->engine_->SetLanguage(lang);
-
+  
   d_->engine_->SetUser(buzz::Jid(settings.user(), settings.host(), STR_EMPTY));
+  // Set connection socket server
+  d_->engine_->SetSocketServer(settings.server().hostname(), (int)settings.server().port());
 
   d_->pass_ = settings.pass();
   d_->auth_mechanism_ = settings.auth_mechanism();
@@ -165,7 +167,6 @@ XmppReturnStatus XmppClient::Connect(
   d_->proxy_port_ = settings.proxy_port();
   d_->allow_plain_ = settings.allow_plain();
   d_->pre_auth_.reset(pre_auth);
-
   return XMPP_RETURN_OK;
 }
 

--- a/talk/xmpp/xmppengine.h
+++ b/talk/xmpp/xmppengine.h
@@ -228,6 +228,10 @@ public:
   //! Sets language
   virtual void SetLanguage(const std::string & lang) = 0;
 
+  //! Sets connection port
+  virtual void SetSocketServer(const std::string& server,
+                               int port) = 0;
+
   // SESSION MANAGEMENT ---------------------------------------------------
 
   //! Set callback for state changes.

--- a/talk/xmpp/xmpplogintask.h
+++ b/talk/xmpp/xmpplogintask.h
@@ -86,6 +86,7 @@ private:
   LoginTaskState state_;
   const XmlElement * pelStanza_;
   bool isStart_;
+  bool isRestart_;
   std::string iqId_;
   talk_base::scoped_ptr<XmlElement> pelFeatures_;
   Jid fullJid_;


### PR DESCRIPTION
//cc: @dscherba @digitalmouse12 @willkelleher 

introduce a singleton object simplebosh to wrap all outgoing xmpp xml message into a suitable http request.
This object also parse the incoming http message to get the xml content to process.
Two class util and tag is used to support simplebosh object to do its functionality.
