### PR TITLE
CHROM-201: Use Chromium Speex GYP

### DIFF
--- a/all.gyp
+++ b/all.gyp
@@ -12,9 +12,6 @@
     'include_tests%': 1,
     'webrtc_root_additional_dependencies': [
     ],
-    # these must be set in GYP_DEFINES
-    'speex_include': '',
-    'speex_lib': '',
   },
   'targets': [
     {

--- a/webrtc/modules/audio_coding/codecs/speex/speex.gypi
+++ b/webrtc/modules/audio_coding/codecs/speex/speex.gypi
@@ -13,8 +13,10 @@
       'type': 'static_library',
       'include_dirs': [
         'include',
-        '<(speex_include)',
         '<(webrtc_root)',
+      ],
+      'dependencies': [
+          '<(DEPTH)/chromium/src/third_party/speex/speex.gyp:libspeex',
       ],
       'direct_dependent_settings': {
         'include_dirs': [
@@ -26,20 +28,6 @@
         'include/speex_interface.h',
         'speex_interface.c',
       ],
-      'link_settings': {
-        'conditions': [
-            ['OS=="win"', {
-              'libraries':[
-                  '<(speex_lib)/libspeex.lib'
-                ],
-            }],
-            ['OS=="mac" or OS=="linux"', {
-              'libraries':[
-                  '<(speex_lib)/libspeex.a'
-                ],
-            }],
-        ],
-      },
     },
   ], # targets
 }


### PR DESCRIPTION
I just noticed that webrtc pulls in a GYP-compatible Speex project from Chromium. This will prevent us from having to build speex stand-alone for all platforms.

//cc @dscherba 
