### PR TITLE
XMPP: Various fixes for proxy support

### DIFF
--- a/webrtc/build/common.gypi
+++ b/webrtc/build/common.gypi
@@ -171,6 +171,10 @@
   },
   'target_defaults': {
     'conditions': [
+      # Conditionally set _PRODUCT compile flag (to turn on/off product-specific functionality)
+      ['PSY_PRODUCT_DEFINE==1', {
+        'defines': ['_PRODUCT',],
+      }],
       ['restrict_webrtc_logging==1', {
         'defines': ['WEBRTC_RESTRICT_LOGGING',],
       }],

--- a/webrtc/libjingle/xmpp/boshsocket.cc
+++ b/webrtc/libjingle/xmpp/boshsocket.cc
@@ -155,7 +155,15 @@ namespace buzz {
 #ifdef FEATURE_ENABLE_SSL
     if (tls_ != buzz::TLS_DISABLED) {
       first_socket = rtc::SSLAdapter::Create(first_socket);
+// For non-production builds, relax certificate requirements. This will allow the use
+// of a debugging proxy, for example.
+#ifndef _PRODUCT
+      ((rtc::SSLAdapter*)first_socket)->set_ignore_bad_cert(true);
+#endif
       second_socket = rtc::SSLAdapter::Create(second_socket);
+#ifndef _PRODUCT
+      ((rtc::SSLAdapter*)second_socket)->set_ignore_bad_cert(true);
+#endif
     }
 #endif  // FEATURE_ENABLE_SSL
     primary_socket_->socket_ = first_socket;

--- a/webrtc/libjingle/xmpp/boshsocket.cc
+++ b/webrtc/libjingle/xmpp/boshsocket.cc
@@ -40,36 +40,37 @@ namespace buzz {
     BoshSocket *socket = (BoshSocket *)param;
 
     while (running_) {
-      if (!socket->OutputEmpty())
-      {
+      if (!socket->OutputEmpty()) {
         socket->TrySending();
       }
       else {
         time(&current_);
         auto current_socket = socket->GetCurrentSocket();
         auto other_socket = socket->GetOtherSocket();
-        // If there was things is sent before, and we have had inactivity time.
-        if (inactivity_ != 0 && socket->restart_sent_) {
-          if (current_socket != NULL) {
-            if (current_socket->pending_ == false)
-            {
-              // Send empty request
-              std::string temp = "empty";
-              socket->Write(temp.c_str(), temp.length());
-              socket->TrySending(current_socket);
-            }
-          }
-          if (other_socket != NULL) {
-            if (difftime(current_, other_socket->receive_time_) >= inactivity_ / 2) {
-              if (other_socket->pending_ == false) {
+
+        if (current_socket && current_socket->pending_ == false && other_socket && other_socket->pending_ == false) {
+          // If there was things is sent before, and we have had inactivity time.
+          if (inactivity_ != 0 && socket->restart_sent_) {
+            if (current_socket != NULL) {
+              if (current_socket->pending_ == false) {
                 // Send empty request
                 std::string temp = "empty";
                 socket->Write(temp.c_str(), temp.length());
-                socket->TrySending(other_socket);
+                socket->TrySending(current_socket);
               }
             }
+            if (other_socket != NULL) {
+              if (difftime(current_, other_socket->receive_time_) >= inactivity_ / 2) {
+                if (other_socket->pending_ == false) {
+                  // Send empty request
+                  std::string temp = "empty";
+                  socket->Write(temp.c_str(), temp.length());
+                  socket->TrySending(other_socket);
+                }
+              }
+            }
+            Sleep(50);
           }
-          Sleep(50);
         }
       }
     }
@@ -82,8 +83,7 @@ namespace buzz {
     ts.tv_sec = 0;
     ts.tv_nsec = 50 * kMilliToNano;
     while (running_) {
-      if (!socket->OutputEmpty())
-      {
+      if (!socket->OutputEmpty()) {
         socket->TrySending();
       }
       else {
@@ -250,6 +250,7 @@ namespace buzz {
             start_sent_ = false;
           }
           if (is_empty_response) {
+            temp_socket->pending_ = false;
             input_msg.len_ = 0;
           }
           else {
@@ -266,8 +267,9 @@ namespace buzz {
           std::memcpy(input_msg.data_, error.c_str(), error.length());
           input_msg.recv_result_ = true;
         }
-        temp_socket->pending_ = false;
+
         if (input_msg.len_ != 0) {
+          temp_socket->pending_ = false;
           input_queue_.push(input_msg);
           SignalRead();
         }
@@ -418,6 +420,7 @@ namespace buzz {
               start_sent_ = false;
             }
             if (is_empty_response) {
+              temp_socket->pending_ = false;
               input_msg.len_ = 0;
             }
             else {
@@ -434,8 +437,9 @@ namespace buzz {
             std::memcpy(input_msg.data_, error.c_str(), error.length());
             input_msg.recv_result_ = true;
           }
-          temp_socket->pending_ = false;
+
           if (input_msg.len_ != 0) {
+            temp_socket->pending_ = false;
             input_queue_.push(input_msg);
             SignalRead();
           }
@@ -571,15 +575,13 @@ namespace buzz {
   }
 
   void BoshSocket::TrySending() {
-    if (BothConnected()) {
-      if (!BothPending()) {
-        auto temp_socket = GetSocket();
+    if (BothConnected() && !BothPending()) {
+      auto temp_socket = GetSocket();
 #ifndef USE_SSLSTREAM
-        OnWriteEvent(temp_socket->socket_);
+      OnWriteEvent(temp_socket->socket_);
 #else // USE_SSLSTREAM
-        OnEvent(temp_socket->stream_, rtc::SE_WRITE, 0);
+      OnEvent(temp_socket->stream_, rtc::SE_WRITE, 0);
 #endif // USE_SSLSTREAM
-      }
     }
   }
 

--- a/webrtc/libjingle/xmpp/boshsocket.cc
+++ b/webrtc/libjingle/xmpp/boshsocket.cc
@@ -49,7 +49,7 @@ namespace buzz {
         auto current_socket = socket->GetCurrentSocket();
         auto other_socket = socket->GetOtherSocket();
         // If there was things is sent before, and we have had inactivity time.
-        if (inactivity_ != 0) {
+        if (inactivity_ != 0 && socket->restart_sent_) {
           if (current_socket != NULL) {
             if (current_socket->pending_ == false)
             {
@@ -91,7 +91,7 @@ namespace buzz {
         auto current_socket = socket->GetCurrentSocket();
         auto other_socket = socket->GetOtherSocket();
         // If there was things is sent before, and we have had inactivity time.
-        if (inactivity_ != 0) {
+        if (inactivity_ != 0 && socket->restart_sent_) {
           if (current_socket != NULL) {
             if (current_socket->pending_ == false) {
               // Send empty request
@@ -125,7 +125,8 @@ namespace buzz {
                                                  tls_(tls),
                                                  ssl_(false),
                                                  use_proxy_(false),
-                                                 start_sent_(false)
+                                                 start_sent_(false),
+                                                 restart_sent_(false)
   {
     running_ = true;
     inactivity_ = 0;
@@ -297,6 +298,7 @@ namespace buzz {
       }
       else if (temp_data == "restart") {
         generated_data = generator_->GenerateLoginRestart();
+        restart_sent_ = true;
       }
       else if (temp_data == "empty") {
         generated_data = generator_->GenerateEmptyRequest();
@@ -458,6 +460,7 @@ namespace buzz {
         }
         else if (temp_data == "restart") {
           generated_data = generator_->GenerateLoginRestart();
+          restart_sent_ = true;
         }
         else if (temp_data == "empty") {
           generated_data = generator_->GenerateEmptyRequest();

--- a/webrtc/libjingle/xmpp/boshsocket.h
+++ b/webrtc/libjingle/xmpp/boshsocket.h
@@ -110,6 +110,8 @@ namespace buzz {
     sigslot::signal1<int> SignalCloseEvent;
     buzz::BoshXmppStanzaGenerator* GetGenerator() { return generator_;}
 
+    bool restart_sent_;
+
   private:
     bool BothPending();
     bool BothConnected();

--- a/webrtc/libjingle/xmpp/xmppclient.cc
+++ b/webrtc/libjingle/xmpp/xmppclient.cc
@@ -140,7 +140,30 @@ XmppReturnStatus XmppClient::Connect(
   std::string user_agent = "default";
   rtc::ProxyInfo proxyInfo;
 
-  rtc::GetProxySettingsForUrl(user_agent.c_str(), server_name.c_str(), &proxyInfo, true);
+  // Construct a full URL for the proxy lookup.
+  std::string server_url;
+  if (settings.server().port() == buzz::XMPP_PORT)
+  {
+      server_url = "xmpp://" + server_name + ":" + std::to_string(buzz::XMPP_PORT);
+  }
+  else if (settings.server().port() == buzz::HTTP_PORT)
+  {
+      server_url = "http://" + server_name;
+  }
+  else if (settings.server().port() == buzz::HTTPS_PORT)
+  {
+      server_url = "https://" + server_name;
+  }
+
+  LOG(LS_INFO) << "Fetching proxy info for URL " << server_url.c_str();
+  rtc::GetProxySettingsForUrl(user_agent.c_str(), server_url.c_str(), &proxyInfo, true);
+  LOG(LS_INFO) << "ProxyInfo: " << std::endl
+      << "   type: " << rtc::ProxyToString(proxyInfo.type) << std::endl
+      << "   address: " << proxyInfo.address.ToString() << std::endl
+      << "   autoconf_url: " << proxyInfo.autoconfig_url << std::endl
+      << "   autodetect: " << proxyInfo.autodetect << std::endl
+      << "   bypass_list: " << proxyInfo.bypass_list << std::endl
+      << "   username: " << proxyInfo.username << std::endl;
 
   // Set language
   d_->engine_->SetLanguage(lang);


### PR DESCRIPTION
- Properly handle different protocols (xmpp, http, https) during proxy auto detection
- BOSH stability fixes (don't reorder rids!)
- Make BOSH XMPP stanza receiver a bit less liberal, able to handle simple fragmented messages
