### PR TITLE
CHROM-355: Allow deinitializing global jni variables

### DIFF
--- a/talk/app/webrtc/java/jni/jni_helpers.cc
+++ b/talk/app/webrtc/java/jni/jni_helpers.cc
@@ -100,6 +100,11 @@ jint InitGlobalJniVariables(JavaVM *jvm) {
   return JNI_VERSION_1_6;
 }
 
+void UninitGlobalJniVariables() {
+  CHECK(g_jvm) << "g_jvm was already null";
+  g_jvm = nullptr;
+}
+
 // Return thread ID as a string.
 static std::string GetThreadId() {
   char buf[21];  // Big enough to hold a kuint64max plus terminating NULL.

--- a/talk/app/webrtc/java/jni/jni_helpers.h
+++ b/talk/app/webrtc/java/jni/jni_helpers.h
@@ -54,6 +54,8 @@ namespace webrtc_jni {
 
 jint InitGlobalJniVariables(JavaVM *jvm);
 
+void UninitGlobalJniVariables();
+
 // Return a |JNIEnv*| usable on this thread or NULL if this thread is detached.
 JNIEnv* GetEnv();
 


### PR DESCRIPTION
Appears to work fine on both ARM and x64. My StagePresence PR will have the precompiled libs with this change

//cc @digitalmouse12 
