### PR TITLE
BOSH: Add locking around queue operations, stanza processing fix 

### DIFF
--- a/webrtc/libjingle/xmpp/boshsocket.h
+++ b/webrtc/libjingle/xmpp/boshsocket.h
@@ -6,11 +6,16 @@
 #include "webrtc/libjingle/xmpp/xmppstanzagenerator.h"
 #include "webrtc/base/asyncsocket.h"
 #include "webrtc/base/bytebuffer.h"
+#include "webrtc/base/scoped_ptr.h"
 #include "webrtc/base/sigslot.h"
 #include <queue>
 #include <string>
 #include <time.h>
 #include <cstring>
+
+namespace webrtc {
+    class CriticalSectionWrapper;
+}
 
 namespace rtc {
   class StreamInterface;
@@ -98,7 +103,7 @@ namespace buzz {
     virtual void SetProxy(const std::string & host, int port);
     virtual void SetInfo(const std::string & domain,
                          const std::string & lang);
-    bool OutputEmpty() { return output_queue_.empty();}
+    bool OutputEmpty();
     void TrySending();
     void TrySending(ManagedSocket* socket);
     buzz::ManagedSocket* GetCurrentSocket() {
@@ -132,7 +137,9 @@ namespace buzz {
     rtc::ByteBuffer buffer_;
     buzz::TlsOptions tls_;
 
+    rtc::scoped_ptr<webrtc::CriticalSectionWrapper> output_queue_crit_;
     std::queue<buzz::OutputMsg> output_queue_;
+    rtc::scoped_ptr<webrtc::CriticalSectionWrapper> input_queue_crit_;
     std::queue<buzz::InputMsg> input_queue_;
 
     bool start_sent_;

--- a/webrtc/libjingle/xmpp/xmppstanzagenerator.cc
+++ b/webrtc/libjingle/xmpp/xmppstanzagenerator.cc
@@ -253,7 +253,7 @@ namespace buzz{
 
       // Remove the <body...> and </body> tags
       if (stop != std::string::npos) { // Partial body (start of a message)
-        content = content.substr(0, stop);
+        str = content.substr(0, stop);
         return true;
       }
       else {


### PR DESCRIPTION
- Certain termination flows (e.g. signout) hit this codepath
