### PR TITLE
Video Capture (webcam): [HACK] do synch frame notifications

### DIFF
--- a/talk/media/webrtc/webrtcvideocapturer.cc
+++ b/talk/media/webrtc/webrtcvideocapturer.cc
@@ -387,6 +387,10 @@ void WebRtcVideoCapturer::OnIncomingCapturedFrame(
         // Note that this results in a shallow copying of the frame.
         rtc::Bind(&WebRtcVideoCapturer::SignalFrameCapturedOnStartThread,
                   this, sample));
+
+    // HACK: make this behave synchronously so we don't flood recipient thread
+    // with video frames
+    async_invoker_->Flush(start_thread_);
   }
 }
 


### PR DESCRIPTION
- Recent change moved webcam video capture to asynchronous
  signals towards upper layers
- But some upper layers (e.g. P4C) have heavyweight handlers
  - Heavyweight enough to not service the thread message queue
  - ... which can create a pileup of video frames
