### PR TITLE
2016-12-26: Update Junit Link

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -18,7 +18,7 @@ deps = {
     Var('chromium_git') + '/external/gflags/src@e7390f9185c75f8d902c05ed7d20bb94eb914d0c', # from svn revision 82
 
   'src/third_party/junit-jar':
-    Var('chromium_git') + '/external/webrtc/deps/third_party/junit@f35596b476aa6e62fd3b3857b9942ddcd13ce35e', # from svn revision 3367
+    Var('chromium_git') + '/external/junit@9e98a85ecf6e857523fcda9150756297a64bccba',
 }
 
 deps_os = {


### PR DESCRIPTION
I recently had issues with building webrtc2 (I realized it's related to Anaconda2 and Python(x,y) for me. Anaconda2 doesn't work for me if I need to compile webrtc2). To solve the issue, I had to delete the wertc2 stuff several times and seems that the link for `junit` has recently been changed.
By changing this, it seems to be working for me okay. But I'm not sure if this's good enough or this's the only thing that needs to be changed.